### PR TITLE
Disable test broken test

### DIFF
--- a/EngLang.Tests/LanguageConversion/BaseVariableTests.cs
+++ b/EngLang.Tests/LanguageConversion/BaseVariableTests.cs
@@ -22,8 +22,8 @@ public abstract class BaseVariableTests
 
     protected abstract string GetExpectedVariable();
 
-    [Fact]
-    public void ConvertVariableWithStringLiteral()
+    [Fact(Skip = "Right now it's not clear to me should I have type string as reserved name, or not. For now it is, but previously it wasn't since it's nice for C# interop")]
+    public void ConvertVariableWithStringType()
     {
         var sentence = "the greetings is an string equal to \"Hello\"";
         var parseResult = EngLangParser.Parse(sentence);
@@ -31,11 +31,26 @@ public abstract class BaseVariableTests
 
         var result = converter.Convert(parseResult);
 
-        var expectedCode = GetExpectedVariableWithStringLiteral();
+        var expectedCode = GetExpectedVariableWithStringType();
         Assert.Equal(expectedCode, result);
     }
 
-    protected abstract string GetExpectedVariableWithStringLiteral();
+    protected abstract string GetExpectedVariableWithStringType();
+
+    [Fact]
+    public void ConvertVariableWithStringName()
+    {
+        var sentence = "the string is an charseq equal to \"Hello\"";
+        var parseResult = EngLangParser.Parse(sentence);
+        var converter = CreateConverter();
+
+        var result = converter.Convert(parseResult);
+
+        var expectedCode = GetExpectedVariableWithStringName();
+        Assert.Equal(expectedCode, result);
+    }
+
+    protected abstract string GetExpectedVariableWithStringName();
 
     [Fact]
     public void ConvertVariableWithIntLiteral()

--- a/EngLang.Tests/LanguageConversion/CSharpVariableTests.cs
+++ b/EngLang.Tests/LanguageConversion/CSharpVariableTests.cs
@@ -10,7 +10,9 @@ public class CSharpVariableTests : BaseVariableTests
     protected override string GetExpectedVariable() => @"apple name;
 ".ReplaceLineEndings(NewLine);
 
-    protected override string GetExpectedVariableWithStringLiteral() => "string greetings = \"Hello\"";
+    protected override string GetExpectedVariableWithStringType() => "string greetings = \"Hello\"";
+
+    protected override string GetExpectedVariableWithStringName() => "charseq @string = \"Hello\"";
 
     protected override string GetExpectedVariableWithIntLiteral() => "number answer = 42";
 

--- a/EngLang.Tests/LanguageConversion/JavaScriptVariableTests.cs
+++ b/EngLang.Tests/LanguageConversion/JavaScriptVariableTests.cs
@@ -10,7 +10,9 @@ public class JavaScriptVariableTests : BaseVariableTests
     protected override string GetExpectedVariable() => @"let name;
 ".ReplaceLineEndings(NewLine);
 
-    protected override string GetExpectedVariableWithStringLiteral() => "let greetings = \"Hello\"";
+    protected override string GetExpectedVariableWithStringType() => "let greetings = \"Hello\"";
+
+    protected override string GetExpectedVariableWithStringName() => "let string = \"Hello\"";
 
     protected override string GetExpectedVariableWithIntLiteral() => "let answer = 42";
 


### PR DESCRIPTION
Rationale: https://github.com/kant2002/EngLang/issues/52

Provide alternative test where we check that variable name `string` escaped properly